### PR TITLE
error 500

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   config.active_storage.service = :cloudinary
 
   # Don't care if the mailer can't send.
-  config.action_mailer.default_url_options = { host: 'https://ugly-xmas-pull-overs.herokuapp.com/users/sign_in' }
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "ugly_Xmas_pull_overs_app_production"
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: 'https://ugly-xmas-pull-overs.herokuapp.com/', port: 3000 }
+  config.action_mailer.default_url_options = { host: 'https://ugly-xmas-pull-overs.herokuapp.com/users/sign_in', port: 3000 }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
Normalement l'error 500 ne devrait plus apparaître au moment de l'envoie du mail de récupération de mdp